### PR TITLE
chore: update node engine to >=24 for active LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
## Summary
- Update node engine requirement from `>=20` to `>=24` to target Node.js 24 active LTS

## Test plan
- [ ] Verify CI passes with Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)